### PR TITLE
Add FiveM playtime reward script

### DIFF
--- a/playtime_reward/client.lua
+++ b/playtime_reward/client.lua
@@ -1,0 +1,50 @@
+local currentTime = 0
+local threshold = 1
+local reward = 0
+
+RegisterNetEvent('playtimeReward:updateTime')
+AddEventHandler('playtimeReward:updateTime', function(time, goal, amount)
+    currentTime = time
+    threshold = goal
+    reward = amount
+end)
+
+Citizen.CreateThread(function()
+    while true do
+        TriggerServerEvent('playtimeReward:requestTime')
+        Citizen.Wait(60000)
+    end
+end)
+
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
+        local remaining = threshold - currentTime
+        if remaining < 0 then remaining = 0 end
+        local days = math.floor(remaining / 86400)
+        local hours = math.floor((remaining % 86400) / 3600)
+        local minutes = math.floor((remaining % 3600) / 60)
+        local progress = remaining / threshold
+        local width = 0.2
+        local x = 0.5
+        local y = 0.85
+
+        DrawRect(x, y, width, 0.02, 0, 0, 0, 150)
+        DrawRect(x - width/2 * (1 - progress), y, width * progress, 0.02, 0, 255, 0, 200)
+
+        SetTextFont(0)
+        SetTextProportional(1)
+        SetTextScale(0.3, 0.3)
+        SetTextColour(255,255,255,255)
+        SetTextEntry("STRING")
+        AddTextComponentString(string.format("Belohnung: $%d   Verbleibend: %dT %dH %dM", reward, days, hours, minutes))
+        DrawText(x - width/2, y - 0.03)
+    end
+end)
+
+RegisterNetEvent('playtimeReward:grant')
+AddEventHandler('playtimeReward:grant', function(amount)
+    SetNotificationTextEntry('STRING')
+    AddTextComponentSubstringPlayerName('Du hast eine Belohnung erhalten: $'..amount)
+    DrawNotification(false, false)
+end)

--- a/playtime_reward/fxmanifest.lua
+++ b/playtime_reward/fxmanifest.lua
@@ -1,0 +1,14 @@
+fx_version 'cerulean'
+game 'gta5'
+
+author 'Codex'
+description 'Playtime reward system'
+version '1.0.0'
+
+server_scripts {
+    'server.lua'
+}
+
+client_scripts {
+    'client.lua'
+}

--- a/playtime_reward/server.lua
+++ b/playtime_reward/server.lua
@@ -1,0 +1,50 @@
+local rewardThreshold = 5 * 24 * 60 * 60 -- 5 Tage in Sekunden
+local rewardAmount = 1500000
+
+local playerTimes = {}
+local saveFile = 'playtime_reward.json'
+
+local function loadTimes()
+    local data = LoadResourceFile(GetCurrentResourceName(), saveFile)
+    if data then
+        playerTimes = json.decode(data)
+    end
+end
+
+local function saveTimes()
+    SaveResourceFile(GetCurrentResourceName(), saveFile, json.encode(playerTimes), -1)
+end
+
+AddEventHandler('playerConnecting', function()
+    local src = source
+    if not playerTimes[src] then
+        playerTimes[src] = 0
+    end
+end)
+
+AddEventHandler('playerDropped', function()
+    saveTimes()
+end)
+
+Citizen.CreateThread(function()
+    loadTimes()
+    while true do
+        Citizen.Wait(60000)
+        for _, player in ipairs(GetPlayers()) do
+            local id = tonumber(player)
+            playerTimes[id] = (playerTimes[id] or 0) + 60
+            if playerTimes[id] >= rewardThreshold then
+                TriggerClientEvent('playtimeReward:grant', id, rewardAmount)
+                playerTimes[id] = playerTimes[id] - rewardThreshold
+            end
+        end
+        saveTimes()
+    end
+end)
+
+RegisterNetEvent('playtimeReward:requestTime')
+AddEventHandler('playtimeReward:requestTime', function()
+    local src = source
+    local time = playerTimes[src] or 0
+    TriggerClientEvent('playtimeReward:updateTime', src, time, rewardThreshold, rewardAmount)
+end)


### PR DESCRIPTION
## Summary
- add fxmanifest and Lua scripts implementing a playtime reward system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6884fdd1a33c83268d3f90ae93857072